### PR TITLE
SVCPLAN-800: Allow slurm stats mysql calls to permit empty password

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ profile_slurm::compute::storage::tmpfs_dir_refreshed_by: "Mount[/local]"
 ```
 
 You will want to set these hiera variables for scheduler nodes:
-```
+```yaml
 profile_slurm::scheduler::firewall::sources:
   - "192.168.0.0/24"  # Allow access to slurmdbd and slurmctld from 192.168.0.0/24 net
 # and generally specify dependencies on local storage:
@@ -76,9 +76,20 @@ profile_slurm::scheduler::storage::storage_dependencies:
   - "Mount['/var/spool/slurmctld.state']"
 ```
 
+### Telegraf Monitoring
+
 You will want to set these hiera variables for a node running the telegraf monitoring:
-```
+```yaml
 profile_slurm::telegraf::telegraf::slurm_job_table: ""
+```
+
+If using MySQL ***with*** socket authentication, you'll also need to set the following because the `telegraf` user cannot use socket auth to connect as another user:
+```yaml
+profile_slurm::telegraf::slurm_username: "telegraf"
+```
+
+If using MySQL ***without*** socket authentication, you'll also need to set the following to lookup the password:
+```yaml
 profile_slurm::telegraf::telegraf::slurm_password: "%{lookup('slurm::slurmdbd_storage_pass')}"  # This is a VAULT lookup, use the keyname you have chosen for storing the slurmdb user account password
 ```
 
@@ -90,5 +101,4 @@ n/a
 ## Reference
 
 See: [REFERENCE.md](REFERENCE.md)
-
 

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -423,9 +423,12 @@ Slurm job table to query
 
 ##### <a name="slurm_password"></a>`slurm_password`
 
-Data type: `String`
+Data type: `Optional[String]`
 
 Password for the slurm user account
+Leave blank if using MySQL socket authentication
+
+Default value: `''`
 
 ##### <a name="slurm_path"></a>`slurm_path`
 

--- a/data/common.yaml
+++ b/data/common.yaml
@@ -38,6 +38,6 @@ profile_slurm::telegraf::telegraf::required_pkgs:
 profile_slurm::telegraf::telegraf::script_path: "/etc/telegraf/scripts/slurm"
 profile_slurm::telegraf::telegraf::slurm_database: "slurm_acct_db"
 profile_slurm::telegraf::telegraf::slurm_job_table: ""
-profile_slurm::telegraf::telegraf::slurm_password: ""  # Needs to be setup as a VAULT lookup in your project control repo
+profile_slurm::telegraf::telegraf::slurm_password: ""  # Needs to be setup as a VAULT lookup in your project control repo OR can be empty if using socket auth
 profile_slurm::telegraf::telegraf::slurm_path: "/usr/bin"
 profile_slurm::telegraf::telegraf::slurm_username: "slurmdbd"

--- a/manifests/telegraf/telegraf.pp
+++ b/manifests/telegraf/telegraf.pp
@@ -17,6 +17,7 @@
 #
 # @param slurm_password
 #   Password for the slurm user account
+#   Leave blank if using MySQL socket authentication
 #
 # @param slurm_path
 #   Path to slurm bin
@@ -33,16 +34,16 @@ class profile_slurm::telegraf::telegraf (
   String $script_path,
   String $slurm_database,
   String $slurm_job_table,
-  String $slurm_password,
   String $slurm_path,
   String $slurm_username,
+  Optional[String] $slurm_password='',
 ){
 
   if ($enable) {
     $ensure_parm = 'present'
 
-    if ($slurm_job_table.empty) or ($slurm_password.empty) {
-      fail('One or more of these required values is not set: slurm_job_table slurm_password ')
+    if ($slurm_job_table.empty) {
+      fail('This required value is not set: slurm_job_table')
     }
 
     ensure_packages( $required_pkgs )

--- a/templates/slurm_detail_stats.sh.epp
+++ b/templates/slurm_detail_stats.sh.epp
@@ -5,6 +5,14 @@
 
 source <%= $source_path %>
 
+if [ -z "$password" ]
+then
+  # ASSUME NO PASSWORD NECESSARY, e.g. USING SOCKET
+  mysqlpass=""
+else
+  mysqlpass="-p${password}"
+fi
+
 ## Setup temp files and define path to slurm
 tfile=$(mktemp /tmp/slurm_node.XXXXXX)
 tfile2=$(mktemp /tmp/squeue.XXXXXX)
@@ -237,7 +245,7 @@ do
 done
 
 ## Job Time Pending Data
-mysql -u ${username} -p${password} -D ${database} -e "select id_user,\`partition\`,MAX(UNIX_TIMESTAMP(NOW())-time_submit) as "MAX_PENDING_TIME",AVG(UNIX_TIMESTAMP(NOW())-time_submit) as "AVG_PENDING_TIME" from ${job_table} where state = 'pending' group by \`partition\`,id_user;" | grep -v id_user > ${tfile}
+mysql -u ${username}  ${mysqlpass} -D ${database} -e "select id_user,\`partition\`,MAX(UNIX_TIMESTAMP(NOW())-time_submit) as "MAX_PENDING_TIME",AVG(UNIX_TIMESTAMP(NOW())-time_submit) as "AVG_PENDING_TIME" from ${job_table} where state = 'pending' group by \`partition\`,id_user;" | grep -v id_user > ${tfile}
 while read -r p; do
 	IFS=" " read id_user partition max_pending_time avg_pending_time <<< "$(echo ${p})"	
 	user=$(getent passwd ${id_user} | cut -d':' -f 1)
@@ -246,7 +254,7 @@ while read -r p; do
 	fi
 done < "${tfile}"
 
-mysql -u ${username} -p${password} -D ${database} -e "select id_group,\`partition\`,MAX(UNIX_TIMESTAMP(NOW())-time_submit) as "MAX_PENDING_TIME",AVG(UNIX_TIMESTAMP(NOW())-time_submit) as "AVG_PENDING_TIME" from ${job_table} where state = 'pending' group by \`partition\`,id_group;" | grep -v id_group > ${tfile}
+mysql -u ${username}  ${mysqlpass} -D ${database} -e "select id_group,\`partition\`,MAX(UNIX_TIMESTAMP(NOW())-time_submit) as "MAX_PENDING_TIME",AVG(UNIX_TIMESTAMP(NOW())-time_submit) as "AVG_PENDING_TIME" from ${job_table} where state = 'pending' group by \`partition\`,id_group;" | grep -v id_group > ${tfile}
 while read -r p; do
         IFS=" " read id_group partition max_pending_time avg_pending_time <<< "$(echo ${p})"
         groupname=$(getent group ${id_group} | cut -d':' -f 1)

--- a/templates/slurm_job_efficiency.sh.epp
+++ b/templates/slurm_job_efficiency.sh.epp
@@ -6,7 +6,15 @@
 tfile=$(mktemp /tmp/seff.XXXXXX)
 source <%= $source_path %>
 
-jobs=($(mysql -u ${username} -p${password} -D ${database} -e "select id_job from ${job_table} where time_end > UNIX_TIMESTAMP(now() - interval 1 hour) and exit_code = '0' and array_task_pending = '0'" | grep -v id_job))
+if [ -z "$password" ]
+then
+  # ASSUME NO PASSWORD NECESSARY, e.g. USING SOCKET
+  mysqlpass=""
+else
+  mysqlpass="-p${password}"
+fi
+
+jobs=($(mysql -u ${username} ${mysqlpass} -D ${database} -e "select id_job from ${job_table} where time_end > UNIX_TIMESTAMP(now() - interval 1 hour) and exit_code = '0' and array_task_pending = '0'" | grep -v id_job))
 
 for j in ${jobs[@]}
 do


### PR DESCRIPTION
See: https://jira.ncsa.illinois.edu/browse/SVCPLAN-800

We are moving towards defaulting to using MySQL socket authentication on slurm controllers. This does not use a normal MySQL password, so this module has been changed to allow an empty password which results in skipping providing the password parameter to MySQL CLI commands.

@jakerundall I'm not sure where or how I can test this. Can you test this branch on `hli-sched`?