### PR TITLE
SVC-20393: configure local disks for Slurm

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -6,12 +6,15 @@
 
 ### Classes
 
-* [`profile_slurm`](#profile_slurm): A short summary of the purpose of this class
+* [`profile_slurm`](#profile_slurm): Blank init, profiles should include other classes in this module
 * [`profile_slurm::client`](#profile_slurmclient): Setup slurm config for slurm client
 * [`profile_slurm::client::firewall`](#profile_slurmclientfirewall): Setup firewall on slurm client
+* [`profile_slurm::compute`](#profile_slurmcompute): Setup slurm config for slurm compute node
+* [`profile_slurm::compute::storage`](#profile_slurmcomputestorage): Setup underlying storage for slurm compute nodes
 * [`profile_slurm::monitor`](#profile_slurmmonitor): Sets up monitoring and collecting of slurm scheduler stats
 * [`profile_slurm::scheduler`](#profile_slurmscheduler): Sets up configs for scheduler node
 * [`profile_slurm::scheduler::firewall`](#profile_slurmschedulerfirewall): Setup firewall on slurm scheduler
+* [`profile_slurm::scheduler::storage`](#profile_slurmschedulerstorage)
 * [`profile_slurm::telegraf::slurm_detail_stats`](#profile_slurmtelegrafslurm_detail_stats): Configure the telegraf collection script slurm_detail_stats
 * [`profile_slurm::telegraf::slurm_job_efficiency`](#profile_slurmtelegrafslurm_job_efficiency): Configure the telegraf collection script slurm_job_efficiency
 * [`profile_slurm::telegraf::slurm_stats`](#profile_slurmtelegrafslurm_stats): Configure the telegraf collection script slurm_stats
@@ -21,7 +24,7 @@
 
 ### <a name="profile_slurm"></a>`profile_slurm`
 
-A description of what this class does
+Blank init, profiles should include other classes in this module
 
 #### Examples
 
@@ -73,6 +76,83 @@ Destination ports that need to be open for the slurmd service
 Data type: `Array[String]`
 
 Array of CIDRs that need to be open for the slurmd service
+
+### <a name="profile_slurmcompute"></a>`profile_slurm::compute`
+
+Setup slurm config for slurm compute node
+
+#### Examples
+
+##### 
+
+```puppet
+include profile_slurm::compute
+```
+
+### <a name="profile_slurmcomputestorage"></a>`profile_slurm::compute::storage`
+
+Setup underlying storage for slurm compute nodes
+
+#### Examples
+
+##### 
+
+```puppet
+include profile_slurm::scheduler::storage
+```
+
+#### Parameters
+
+The following parameters are available in the `profile_slurm::compute::storage` class:
+
+* [`require_storage`](#require_storage)
+* [`storage_dependencies`](#storage_dependencies)
+* [`tmpfs_dir`](#tmpfs_dir)
+* [`tmpfs_dir_refresh_command`](#tmpfs_dir_refresh_command)
+* [`tmpfs_dir_refreshed_by`](#tmpfs_dir_refreshed_by)
+
+##### <a name="require_storage"></a>`require_storage`
+
+Data type: `Array[String]`
+
+Optionally list resources (e.g., services) that require storage
+in order to function.
+
+##### <a name="storage_dependencies"></a>`storage_dependencies`
+
+Data type: `Array[String]`
+
+Optionally list resources (e.g. mounts) that should be present before
+setting up Slurm on a compute node. Should be in the form that would
+be specified as a requirement ("before") various Slurm compute (slurmd)
+resources, e.g.:
+  - "Lvm::Logical_volume::local"
+
+##### <a name="tmpfs_dir"></a>`tmpfs_dir`
+
+Data type: `Optional[String]`
+
+Directory to create for job_container/tmpfs ("job /tmp" directory).
+Created by File resource or Exec depending on value of
+$tmpfs_dir_refeshed_by.
+E.g.: "/local/slurmjobs"
+
+##### <a name="tmpfs_dir_refresh_command"></a>`tmpfs_dir_refresh_command`
+
+Data type: `Optional[String]`
+
+Optional command that should refresh $tmpfs_dir. If not specified,
+then "rm -rf ${tmpfs_dir}" will be used.
+
+##### <a name="tmpfs_dir_refreshed_by"></a>`tmpfs_dir_refreshed_by`
+
+Data type: `Optional[String]`
+
+Resource which $tmpfs_dir requires and which should cause it to be
+refreshed (removed and recreated). If this is NOT defined, and
+$tmpfs_dir IS defined, then Puppet will simply ensure that $tmpfs_dir
+exists.
+E.g.: "Lvm::Logical_volume['local']"
 
 ### <a name="profile_slurmmonitor"></a>`profile_slurm::monitor`
 
@@ -135,6 +215,42 @@ Destination port that need to be open for the slurmdbd service
 Data type: `Array[String]`
 
 Array of CIDRs that need to be open for the slurmctld and slurmdbd service
+
+### <a name="profile_slurmschedulerstorage"></a>`profile_slurm::scheduler::storage`
+
+The profile_slurm::scheduler::storage class.
+
+#### Examples
+
+##### 
+
+```puppet
+include profile_slurm::scheduler::storage
+```
+
+#### Parameters
+
+The following parameters are available in the `profile_slurm::scheduler::storage` class:
+
+* [`storage_dependencies`](#storage_dependencies)
+* [`require_storage`](#require_storage)
+
+##### <a name="storage_dependencies"></a>`storage_dependencies`
+
+Data type: `Array[String]`
+
+Optionally list resources (e.g. mounts) that should be present before
+setting up Slurm on a scheduler. Should be in the form that would
+be specified as a requirement ("before") various Slurm scheduler
+resources, e.g.:
+  Lvm::Logical_volume::mysql
+  Lvm::Logical_volume::slurm
+
+##### <a name="require_storage"></a>`require_storage`
+
+Data type: `Array[String]`
+
+
 
 ### <a name="profile_slurmtelegrafslurm_detail_stats"></a>`profile_slurm::telegraf::slurm_detail_stats`
 

--- a/data/common.yaml
+++ b/data/common.yaml
@@ -3,9 +3,22 @@
 profile_slurm::client::firewall::slurmd_port: 6818
 profile_slurm::client::firewall::sources: []
 
+profile_slurm::compute::storage::require_storage:
+  - "Service['slurmd']"
+profile_slurm::compute::storage::storage_dependencies: []
+profile_slurm::compute::storage::tmpfs_dir: null
+profile_slurm::compute::storage::tmpfs_dir_refresh_command: null
+profile_slurm::compute::storage::tmpfs_dir_refreshed_by: null
+
 profile_slurm::scheduler::firewall::slurmdbd_port: 6819
 profile_slurm::scheduler::firewall::slurmctld_port: 6817
 profile_slurm::scheduler::firewall::sources: []
+
+profile_slurm::scheduler::storage::require_storage:
+  - "Service['mysqld']"
+  - "Service['slurmctld']"
+  - "Service['slurmdbd']"
+profile_slurm::scheduler::storage::storage_dependencies: []
 
 profile_slurm::telegraf::slurm_detail_stats::enable: true
 profile_slurm::telegraf::slurm_detail_stats::interval: "5m"

--- a/manifests/compute.pp
+++ b/manifests/compute.pp
@@ -1,0 +1,9 @@
+# @summary Setup slurm config for slurm compute node
+#
+# @example
+#   include profile_slurm::compute
+class profile_slurm::compute {
+
+  include profile_slurm::compute::storage
+
+}

--- a/manifests/compute/storage.pp
+++ b/manifests/compute/storage.pp
@@ -1,0 +1,90 @@
+# @summary Setup underlying storage for slurm compute nodes
+#
+# @param require_storage
+#   Optionally list resources (e.g., services) that require storage
+#   in order to function.
+#
+# @param storage_dependencies
+#   Optionally list resources (e.g. mounts) that should be present before
+#   setting up Slurm on a compute node. Should be in the form that would
+#   be specified as a requirement ("before") various Slurm compute (slurmd)
+#   resources, e.g.:
+#     - "Lvm::Logical_volume::local"
+#
+# @param tmpfs_dir
+#   Directory to create for job_container/tmpfs ("job /tmp" directory).
+#   Created by File resource or Exec depending on value of
+#   $tmpfs_dir_refeshed_by.
+#   E.g.: "/local/slurmjobs"
+#
+# @param tmpfs_dir_refresh_command
+#   Optional command that should refresh $tmpfs_dir. If not specified,
+#   then "rm -rf ${tmpfs_dir}" will be used.
+#  
+# @param tmpfs_dir_refreshed_by
+#   Resource which $tmpfs_dir requires and which should cause it to be
+#   refreshed (removed and recreated). If this is NOT defined, and
+#   $tmpfs_dir IS defined, then Puppet will simply ensure that $tmpfs_dir
+#   exists. 
+#   E.g.: "Lvm::Logical_volume['local']"
+#
+# @example
+#   include profile_slurm::scheduler::storage
+#
+class profile_slurm::compute::storage (
+
+  Array[String]    $require_storage,
+  Array[String]    $storage_dependencies,
+  Optional[String] $tmpfs_dir,
+  Optional[String] $tmpfs_dir_refresh_command,
+  Optional[String] $tmpfs_dir_refreshed_by,
+
+){
+
+  # Make sure that underlying storage dependencies (mounts, etc.)
+  # are ensured prior to things that depend on them (e.g., services).
+  $storage_dependencies.each | $dependency |
+  {
+    $require_storage.each | $dependent |
+    {
+      $dependency -> $dependent
+    }
+  }
+
+  # If we manage a tmpfs directory, ensure it prior to $require_storage
+  # resources, and optionally refresh (delete and recreate) the tmpfs directory.
+  if $tmpfs_dir {
+    if $tmpfs_dir_refreshed_by {
+      # we have defined a resource that $tmpfs_dir depends on and
+      # this resource ($tmpfs_dir_refreshed_by) is updated, $tmpfs_dir
+      # will be removed and recreated
+
+      if $tmpfs_dir_refresh_command {
+        $refresh_command = $tmpfs_dir_refresh_command
+      } else {
+        $refresh_command = "rm -rf ${tmpfs_dir}"
+      }
+
+      exec { "refresh_${tmpfs_dir}":
+        before      => File[$tmpfs_dir],
+        command     => $refresh_command,
+        path        => ['/bin', '/usr/bin', '/usr/sbin'],
+        refreshonly => true,
+        subscribe   => $tmpfs_dir_refreshed_by,
+      }
+    }
+
+    # $tmpfs_dir doesn't depend on anything, just ensure it exists
+    file { $tmpfs_dir:
+      ensure => 'directory',
+      group  => 'root',
+      mode   => '0755',
+      owner  => 'root',
+    }
+    $require_storage.each | $dependent |
+    {
+      File[$tmpfs_dir] -> $dependent
+    }
+  }
+
+}

--- a/manifests/scheduler.pp
+++ b/manifests/scheduler.pp
@@ -6,5 +6,6 @@
 class profile_slurm::scheduler {
 
   include profile_slurm::scheduler::firewall
+  include profile_slurm::scheduler::storage
 
 }

--- a/manifests/scheduler/storage.pp
+++ b/manifests/scheduler/storage.pp
@@ -1,0 +1,34 @@
+# @summary Setup underlying storage for slurm scheduler
+#
+# @param require_storage
+#   Optionally list resources (e.g., services) that require storage
+#   in order to function.
+
+# @param storage_dependencies
+#   Optionally list resources (e.g. mounts) that should be present before
+#   setting up Slurm on a scheduler. Should be in the form that would
+#   be specified as a requirement ("before") various Slurm scheduler
+#   resources, e.g.:
+#     Lvm::Logical_volume::mysql
+#     Lvm::Logical_volume::slurm
+#
+# @example
+#   include profile_slurm::scheduler::storage
+class profile_slurm::scheduler::storage (
+
+  Array[String]  $require_storage,
+  Array[String]  $storage_dependencies,
+
+){
+
+  $storage_dependencies.each | $dependency |
+  {
+    $require_storage.each | $dependent |
+    {
+#    $mount -> Service['slurmctld']
+#    $mount -> Service['slurmdbd']
+      $dependency -> $dependent
+    }
+  }
+
+}

--- a/spec/classes/compute/storage_spec.rb
+++ b/spec/classes/compute/storage_spec.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe 'profile_slurm::compute::storage' do
+  on_supported_os.each do |os, os_facts|
+    context "on #{os}" do
+      let(:facts) { os_facts }
+
+      it { is_expected.to compile }
+    end
+  end
+end

--- a/spec/classes/compute_spec.rb
+++ b/spec/classes/compute_spec.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe 'profile_slurm::compute' do
+  on_supported_os.each do |os, os_facts|
+    context "on #{os}" do
+      let(:facts) { os_facts }
+
+      it { is_expected.to compile }
+    end
+  end
+end

--- a/spec/classes/scheduler/storage_spec.rb
+++ b/spec/classes/scheduler/storage_spec.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe 'profile_slurm::scheduler::storage' do
+  on_supported_os.each do |os, os_facts|
+    context "on #{os}" do
+      let(:facts) { os_facts }
+
+      it { is_expected.to compile }
+    end
+  end
+end


### PR DESCRIPTION
add profile_slurm::compute::storage and profile_slurm::scheduler::storage classes
- ensure mount requirements can optionally be enforced
- allow creation (and refresh) of tmpfs_dir