### PR TITLE
SVCPLAN-1825 telegraf group by account

### DIFF
--- a/templates/slurm_detail_stats.sh.epp
+++ b/templates/slurm_detail_stats.sh.epp
@@ -57,7 +57,7 @@ while read -r p; do
 			done
 		## Job uses a GPU(s) so run this
                 else
-                        mem_len=$(echo "${p}" | cut -d'=' -f 3 | sed 's/[^0-9\.]*//g' | wc -c) 
+			mem_len=$(echo "${p}" | cut -d'=' -f 3 | sed 's/[^0-9\.]*//g' | wc -c)
                         mem=$(echo "${p}" | cut -d'=' -f 3 | cut -c 1-"${mem_len}")
                         if [ "$(echo "${mem}" | rev | cut -c 1)" == "M" ]; then
                                 t_alloc=$(echo "${mem}" | cut -d'M' -f 1)
@@ -191,7 +191,7 @@ while read -r p; do
 			done
 		else
 			echo "${partition},${cpu},${mem_allocated},0,${user_name}" >> "${tfile4}"
-		fi	
+		fi
 	else
 		IFS=" " read -r partition cpu mem mem_unit gpu user_name <<< $(echo ${p} | awk -F , '{print $1" "$2" "$3" "$4" "$(NF-2)" "$(NF-1)}')
                 if [ "${mem}" == "M" ]; then
@@ -246,7 +246,7 @@ do
 done
 
 ## Job Time Pending Data
-mysql -u ${username}  ${mysqlpass} -D ${database} -e "select id_user,\`partition\`,MAX(UNIX_TIMESTAMP(NOW())-time_submit) as "MAX_PENDING_TIME",AVG(UNIX_TIMESTAMP(NOW())-time_submit) as "AVG_PENDING_TIME" from ${job_table} where state = 'pending' group by \`partition\`,id_user;" | grep -v id_user > ${tfile}
+mysql -u ${username}  ${mysqlpass} -D ${database} -e "select id_user,\`partition\`,MAX(UNIX_TIMESTAMP(NOW())-time_eligible) as "MAX_PENDING_TIME",AVG(UNIX_TIMESTAMP(NOW())-time_eligible) as "AVG_PENDING_TIME" from ${job_table} where state = 'pending' and time_eligible <= UNIX_TIMESTAMP(NOW()) group by \`partition\`,id_user;" | grep -v id_user > ${tfile}
 while read -r p; do
 	IFS=" " read id_user partition max_pending_time avg_pending_time <<< "$(echo ${p})"
 	user=$(getent passwd ${id_user} | cut -d':' -f 1)
@@ -255,31 +255,45 @@ while read -r p; do
 			parts_for_job=($(echo ${partition} | sed 's/,/\ /g'))
                         for z in ${parts_for_job[@]}
                         do
-				echo "slurm_pending_job_data,partition=${z},user=${user} max_pending_time=${max_pending_time},avg_pending_time=${avg_pending_time}"
+				echo "slurm_pending_job_data,partition=${z},user=${user},type=pending max_pending_time=${max_pending_time},avg_pending_time=${avg_pending_time}"
 			done
 		else
-			echo "slurm_pending_job_data,partition=${partition},user=${user} max_pending_time=${max_pending_time},avg_pending_time=${avg_pending_time}"
+			echo "slurm_pending_job_data,partition=${partition},user=${user},type=pending max_pending_time=${max_pending_time},avg_pending_time=${avg_pending_time}"
 		fi
 	fi
 done < "${tfile}"
 
-mysql -u ${username}  ${mysqlpass} -D ${database} -e "select id_group,\`partition\`,MAX(UNIX_TIMESTAMP(NOW())-time_submit) as "MAX_PENDING_TIME",AVG(UNIX_TIMESTAMP(NOW())-time_submit) as "AVG_PENDING_TIME" from ${job_table} where state = 'pending' group by \`partition\`,id_group;" | grep -v id_group > ${tfile}
+mysql -u ${username}  ${mysqlpass} -D ${database} -e "select account,\`partition\`,MAX(UNIX_TIMESTAMP(NOW())-time_eligible) as "MAX_PENDING_TIME",AVG(UNIX_TIMESTAMP(NOW())-time_eligible) as "AVG_PENDING_TIME" from ${job_table} where state = 'pending' and time_eligible <= UNIX_TIMESTAMP(NOW()) group by \`partition\`,account;" | grep -v account > ${tfile}
 while read -r p; do
-        IFS=" " read id_group partition max_pending_time avg_pending_time <<< "$(echo ${p})"
-        groupname=$(getent group ${id_group} | cut -d':' -f 1)
-        if [[ ${groupname} == [a-z]* ]] && [[ ${partition} == [a-z]* ]]; then
+        IFS=" " read account partition max_pending_time avg_pending_time <<< "$(echo ${p})"
+        if [[ ${account} == [a-z]* ]] && [[ ${partition} == [a-z]* ]]; then
                 if [ -n $(echo ${partition} | grep ",") ]; then
                         parts_for_job=($(echo ${partition} | sed 's/,/\ /g'))
                         for z in ${parts_for_job[@]}
                         do
-				echo "slurm_pending_job_data,partition=${z},group=${groupname} max_pending_time=${max_pending_time},avg_pending_time=${avg_pending_time}"
+				echo "slurm_pending_job_data,partition=${z},account=${account},type=pending max_pending_time=${max_pending_time},avg_pending_time=${avg_pending_time}"
 			done
 		else
-	                echo "slurm_pending_job_data,partition=${partition},group=${groupname} max_pending_time=${max_pending_time},avg_pending_time=${avg_pending_time}"
+	                echo "slurm_pending_job_data,partition=${partition},account=${account},type=pending max_pending_time=${max_pending_time},avg_pending_time=${avg_pending_time}"
 		fi
         fi
 done < "${tfile}"
 
+mysql -u ${username}  ${mysqlpass} -D ${database} -e "select \`partition\`,MAX(time_start-time_eligible) as "MAX_PENDING_TIME",AVG(time_start-time_eligible) as "AVG_PENDING_TIME" from ${job_table} where time_start >= (UNIX_TIMESTAMP(NOW())-300) group by \`partition\`;" | grep -v partition > ${tfile}
+while read -r p; do
+        IFS=" " read partition max_pending_time avg_pending_time <<< "$(echo ${p})"
+        if [[ ${account} == [a-z]* ]] && [[ ${partition} == [a-z]* ]]; then
+                if [ -n $(echo ${partition} | grep ",") ]; then
+                        parts_for_job=($(echo ${partition} | sed 's/,/\ /g'))
+                        for z in ${parts_for_job[@]}
+                        do
+                                echo "slurm_pending_job_data,partition=${z},type=started max_pending_time=${max_pending_time},avg_pending_time=${avg_pending_time}"
+                        done
+                else
+                        echo "slurm_pending_job_data,partition=${partition},type=started max_pending_time=${max_pending_time},avg_pending_time=${avg_pending_time}"
+                fi
+        fi
+done < "${tfile}"
 
 rm -rf "${tfile}"
 rm -rf "${tfile2}"

--- a/templates/slurm_job_efficiency.sh.epp
+++ b/templates/slurm_job_efficiency.sh.epp
@@ -14,17 +14,17 @@ else
   mysqlpass="-p${password}"
 fi
 
-jobs=($(mysql -u ${username} ${mysqlpass} -D ${database} -e "select id_job from ${job_table} where time_end > UNIX_TIMESTAMP(now() - interval 1 hour) and exit_code = '0' and array_task_pending = '0'" | grep -v id_job))
+jobs=($(mysql -u ${username} ${mysqlpass} -D ${database} -e "select id_job,account from ${job_table} where time_end > UNIX_TIMESTAMP(now() - interval 1 hour) and exit_code = '0' and array_task_pending = '0'" | grep -v id_job | sed 's/\t/:/'))
 
 for j in ${jobs[@]}
 do
-	${slurm_path}/seff ${j} > ${tfile}
+	IFS=":" read jobid account <<< "$(echo "${j}")"
+	${slurm_path}/seff ${jobid} > ${tfile}
 	user=$(grep "User/Group" ${tfile} | cut -d'/' -f 2 | cut -d' ' -f 2)
-	group=$(grep "User/Group" ${tfile} | cut -d'/' -f 3)
 	cpu_efficiency=$(grep "CPU Efficiency:" ${tfile} | cut -d' ' -f 3 | cut -d'%' -f 1)
 	mem_efficiency=$(grep "Memory Efficiency:" ${tfile} | cut -d' ' -f 3 | cut -d'%' -f 1)
-	partition=$(${slurm_path}/sacct -P -X -n -o partition%20 -j ${j} | head -n 1)
-	end_stamp=$(${slurm_path}/sacct -P -X -n -o End -j ${j} | sort -r | head -n 1)
+	partition=$(${slurm_path}/sacct -P -X -n -o partition%20 -j ${jobid} | head -n 1)
+	end_stamp=$(${slurm_path}/sacct -P -X -n -o End -j ${jobid} | sort -r | head -n 1)
 	if [ ${end_stamp} != "Unknown" ]; then
 		new_end_time=$(date -d "${end_stamp}" +%s%N | head -n 1)
 		if [ -z ${end_time} ] || [ ${new_end_time} -ne ${end_time} ]; then
@@ -46,11 +46,11 @@ do
 			from_core_time=$(echo ${raw_time} | cut -d'-' -f 2 | awk -F: '{ print ($1 * 3600) + ($2 * 60) + $3 }')
 			core_time=$((from_core_days+from_core_time))
 		fi
-	
+
 		if [ "${core_time}" -ne 0 ]; then
-		echo "slurm_job_efficiency,user=${user},group=${group},partition=${partition} cpu_efficiency=${cpu_efficiency},mem_efficiency=${mem_efficiency},core_time=${core_time},jobid=${j} ${real_end_time}"
+		echo "slurm_job_efficiency,user=${user},account=${account},partition=${partition} cpu_efficiency=${cpu_efficiency},mem_efficiency=${mem_efficiency},core_time=${core_time},jobid=${jobid} ${real_end_time}"
 		fi
-	fi	
+	fi
 done
 
 rm -rf ${tfile}


### PR DESCRIPTION
Pulls in upstream changes from:
https://git.ncsa.illinois.edu/ici-monitoring/ici-developed-checks

Specifically commits:
https://git.ncsa.illinois.edu/ici-monitoring/ici-developed-checks/-/commit/364e20d7646ce7e939088c59701c713741fbe6e6
https://git.ncsa.illinois.edu/ici-monitoring/ici-developed-checks/-/commit/d5e59c48f2a5d385952ee06881419bc097ae9556

Main changes are:
* A lot of slurm stats were grouped by user, group, and partition. Instead
this is changed to group by "account" since that’s really how we do
allocations on systems, not via their group.  All these groups show up
as 202 since that is everyone’s default gid

* Average and Max job wait time was based on subtracting job submit time
from when it ran, not job eligible time so it looked worse than it is;
since it included time job waited due to job chains/queue limits/etc.
Script has been updated to account for this