### PR TITLE
SVCPLAN-2105 Increase column width for long partition and jobs names

### DIFF
--- a/templates/slurm_detail_stats.sh.epp
+++ b/templates/slurm_detail_stats.sh.epp
@@ -20,7 +20,7 @@ tfile3=$(mktemp /tmp/nodeinfo.XXXXXX)
 tfile4=$(mktemp /tmp/pending.XXXXXX)
 
 ##Dump info about all running jobs into a temp file; get the list of all nodes in the system
-"${slurm_path}"/squeue -t running -O Partition,NodeList:50,tres-alloc:70,username | grep -v TRES_ALLOC | awk '{print $1","$2","$3","$4}' > "${tfile2}"
+"${slurm_path}"/squeue -t running -O Partition:50,NodeList:250,tres-alloc:70,username | grep -v TRES_ALLOC | awk '{print $1","$2","$3","$4}' > "${tfile2}"
 all_node_list=($("${slurm_path}"/sinfo -N | grep -v NODELIST | awk '{print $1}' | sort -u | xargs))
 
 ## Loop over that list of jobs running and get the data formatted in consistent way


### PR DESCRIPTION
This pulls down changes upstream at:
https://git.ncsa.illinois.edu/ici-monitoring/ici-developed-checks

Specifically this commit:
https://git.ncsa.illinois.edu/ici-monitoring/ici-developed-checks/-/commit/9012eb99bd993dc9287b6e855fbe22c942647892?view=inline

Details are:
Delta's interactive partitions exceed the default column width in Slurm;
adjusted to widen what we print for parsing from 16 to 50 characters;
also bumped max node list length from 50 characters to 250 as we have
some wide jobs that are exceeding the old limit there as well.