### PR TITLE
SVCPLAN-1695: add crons class

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -11,6 +11,7 @@
 * [`profile_slurm::client::firewall`](#profile_slurmclientfirewall): Setup firewall on slurm client
 * [`profile_slurm::compute`](#profile_slurmcompute): Setup slurm config for slurm compute node
 * [`profile_slurm::compute::storage`](#profile_slurmcomputestorage): Setup underlying storage for slurm compute nodes
+* [`profile_slurm::crons`](#profile_slurmcrons): Manage Ad-hoc crons and related scripts.
 * [`profile_slurm::monitor`](#profile_slurmmonitor): Sets up monitoring and collecting of slurm scheduler stats
 * [`profile_slurm::scheduler`](#profile_slurmscheduler): Sets up configs for scheduler node
 * [`profile_slurm::scheduler::firewall`](#profile_slurmschedulerfirewall): Setup firewall on slurm scheduler
@@ -154,6 +155,37 @@ refreshed (removed and recreated). If this is NOT defined, and
 $tmpfs_dir IS defined, then Puppet will simply ensure that $tmpfs_dir
 exists.
 E.g.: "Lvm::Logical_volume['local']"
+
+### <a name="profile_slurmcrons"></a>`profile_slurm::crons`
+
+Manage Ad-hoc crons and related scripts.
+
+#### Examples
+
+##### 
+
+```puppet
+include profile_slurm::crons
+```
+
+#### Parameters
+
+The following parameters are available in the `profile_slurm::crons` class:
+
+* [`crons`](#crons)
+* [`files`](#files)
+
+##### <a name="crons"></a>`crons`
+
+Data type: `Hash`
+
+Cron resources.
+
+##### <a name="files"></a>`files`
+
+Data type: `Hash`
+
+File resources.
 
 ### <a name="profile_slurmmonitor"></a>`profile_slurm::monitor`
 

--- a/data/common.yaml
+++ b/data/common.yaml
@@ -10,6 +10,9 @@ profile_slurm::compute::storage::tmpfs_dir: null
 profile_slurm::compute::storage::tmpfs_dir_refresh_command: null
 profile_slurm::compute::storage::tmpfs_dir_refreshed_by: null
 
+profile_slurm::crons::crons: {}
+profile_slurm::crons::files: {}
+
 profile_slurm::scheduler::firewall::slurmdbd_port: 6819
 profile_slurm::scheduler::firewall::slurmctld_port: 6817
 profile_slurm::scheduler::firewall::sources: []

--- a/manifests/crons.pp
+++ b/manifests/crons.pp
@@ -1,0 +1,32 @@
+# @summary Manage Ad-hoc crons and related scripts.
+#
+# Manage Ad-hoc crons and related scripts.
+#
+# @param crons
+#   Cron resources.
+#
+# @param files
+#   File resources.
+#
+# @example
+#   include profile_slurm::crons
+class profile_slurm::crons (
+  Hash $crons,
+  Hash $files,
+) {
+
+  $file_defaults = {
+    ensure => file,
+    owner  => 'root',
+    group  => 'root',
+    mode   => '0644',
+  }
+  ensure_resources('file', $files, $file_defaults )
+
+  $cron_defaults = {
+    ensure => present,
+    user   => 'root',
+  }
+  ensure_resources('cron', $crons, $cron_defaults )
+
+}

--- a/spec/classes/crons_spec.rb
+++ b/spec/classes/crons_spec.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe 'profile_slurm::crons' do
+  on_supported_os.each do |os, os_facts|
+    context "on #{os}" do
+      let(:facts) { os_facts }
+
+      it { is_expected.to compile }
+    end
+  end
+end


### PR DESCRIPTION
Tested on control-test-rhel84b.internal.ncsa.edu (just the profile_slurm::crons class, but there are no dependencies).