### PR TITLE
SVCPLAN-6599: mailprog.sh email wrapper for scheduler

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,8 @@ will cause Slurm to send email using an alernate FROM address (something
 other than the node's default FROM address). To do this, define
 `profile_slurm::scheduler::mailprog::sendas_address`. You will still
 need set set MailProg in slurm.conf using the `slurm` Puppet module.
+* A send-as/from address does not need to be a deliverable address, but the intent of this feature is that it would be, and using a deliverable address may decrease the likelihood of email from Slurm being rejected and not delivered.
+* Instructions for setting up a campus email mailbox (which might generally have 'noreply' in its name) are here: https://wiki.ncsa.illinois.edu/display/ICI/Cluster-Specific+Email+Mailbox+for+Root+Email+or+No-Reply
 
 ### Telegraf Monitoring
 

--- a/README.md
+++ b/README.md
@@ -124,6 +124,12 @@ profile_slurm::files::files:
   ...
 ```
 
+A mailprog.sh script can be set up which, when configured as MailProg,
+will cause Slurm to send email using an alernate FROM address (something
+other than the node's default FROM address). To do this, define
+`profile_slurm::scheduler::mailprog::sendas_address`. You will still
+need set set MailProg in slurm.conf using the `slurm` Puppet module.
+
 ### Telegraf Monitoring
 
 You will want to set these hiera variables for a node running the telegraf monitoring:

--- a/data/common.yaml
+++ b/data/common.yaml
@@ -54,6 +54,8 @@ profile_slurm::scheduler::firewall::slurmdbd_port: 6819
 profile_slurm::scheduler::firewall::slurmctld_port: 6817
 profile_slurm::scheduler::firewall::sources: []
 
+profile_slurm::scheduler::mailprog::sendas_address: null
+
 # note: there are no "official" IDs for slurmrestd, but
 # slurm is usually 93 and 94 doesn't seem to be widely used
 profile_slurm::slurmrestd::dependencies:

--- a/manifests/scheduler.pp
+++ b/manifests/scheduler.pp
@@ -35,6 +35,7 @@ class profile_slurm::scheduler (
   include profile_slurm::files
   include profile_slurm::id_check
   include profile_slurm::scheduler::firewall
+  include profile_slurm::scheduler::mailprog
   include systemd
 
   $dependencies.each | $dependency | {

--- a/manifests/scheduler/mailprog.pp
+++ b/manifests/scheduler/mailprog.pp
@@ -1,0 +1,25 @@
+# @summary Creates a mailprog.sh script that can be used as MailProg in slurm.conf.
+#
+# Creates a mailprog.sh script that can be used as MailProg in slurm.conf. MailProg
+# must still be set in slurm.conf using the slurm Puppet module.
+#
+# @param sendas_address
+# Email address that should be used to send email (the FROM address).
+# THIS PARAMETER MUST BE DEFINED TO CREATE THE SCRIPT!
+#
+# @example
+#   include profile_slurm::scheduler::mailprog
+class profile_slurm::scheduler::mailprog (
+  $sendas_address,
+) {
+  # create the mailprog.sh script
+  if $sendas_address {
+    file { '/etc/slurm/mailprog.sh':
+      ensure  => file,
+      content => epp( 'profile_slurm/mailprog.sh.epp' ),
+      owner   => 'root',
+      group   => 'root',
+      mode    => '0755',
+    }
+  }
+}

--- a/spec/classes/scheduler/mailprog_spec.rb
+++ b/spec/classes/scheduler/mailprog_spec.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe 'profile_slurm::scheduler::mailprog' do
+  on_supported_os.each do |os, os_facts|
+    context "on #{os}" do
+      let(:facts) { os_facts }
+
+      it { is_expected.to compile.with_all_deps }
+    end
+  end
+end

--- a/templates/mailprog.sh.epp
+++ b/templates/mailprog.sh.epp
@@ -8,5 +8,7 @@ recipient=${@: -1}
 # all middle args are the subject
 subject=${@:2:$#-2}
 
-# send email with empty body and appropriate subject to the recipient
+# SLURM DOES NOT SEND A BODY TO MAILPROG
+# the entire message is in the subject
+
 echo "" | /bin/mail -r <%= $profile_slurm::scheduler::mailprog::sendas_address %> -s "$subject" $recipient

--- a/templates/mailprog.sh.epp
+++ b/templates/mailprog.sh.epp
@@ -1,0 +1,12 @@
+#!/bin/bash
+# mailprog.sh: Managed by Puppet
+
+# SCRIPT ARGS SENT BY SLURM:
+# first arg is '-s'
+# last arg is recipient email address
+recipient=${@: -1}
+# all middle args are the subject
+subject=${@:2:$#-2}
+
+# send email with empty body and appropriate subject to the recipient
+echo "" | /bin/mail -r <%= $profile_slurm::scheduler::mailprog::sendas_address %> -s "$subject" $recipient


### PR DESCRIPTION
If profile_slurm::scheduler::mailprog::sendas_address is specified, create an /etc/slurm/mailprog.sh script that can be used as MailProg in slurm.conf.